### PR TITLE
Update setup-gradle-composite

### DIFF
--- a/setup-gradle-composite/action.yml
+++ b/setup-gradle-composite/action.yml
@@ -40,8 +40,6 @@ runs:
               submodules: '${{ inputs.checkout_submodules }}'
               fetch-depth: '${{ inputs.checkout_fetch-depth }}'
               persist-credentials: false
-        - name: Validate Gradle Wrapper
-          uses: gradle/actions/wrapper-validation@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - name: Setup Java
           uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
           with:


### PR DESCRIPTION
This updates the versions of the actions we are using for `setup-gradle-composite`. I'm hoping this will fix the random errors when validating the gradle wrappers since some of the code around that has changed in the last year

Removed gradle `wrapper-validation` since its covered under the `setup-gradle` as of 4.4.1