### PR TITLE
Add further customisability to the release action, and store the full tag in release data

### DIFF
--- a/previous-release/README.md
+++ b/previous-release/README.md
@@ -32,8 +32,9 @@ or
 
 ## Outputs
 
-| Output            | Description                                              |
-| ----------------- | -------------------------------------------------------- |
-| `curentRelease`   | If numeric, the incremented tag of the previous release. |
-| `previousRelease` | The tag of the previous release.                         |
-| `previousCommit`  | The commit of the previous release.                      |
+| Output            | Description                                                   |
+|-------------------|---------------------------------------------------------------|
+| `curentRelease`   | If numeric, the incremented base tag of the previous release. |
+| `previousRelease` | The base tag of the previous release.                         |
+| `previousTag`     | The tag of the previous release.                              |
+| `previousCommit`  | The commit of the previous release.                           |

--- a/previous-release/action.yml
+++ b/previous-release/action.yml
@@ -14,8 +14,10 @@ inputs:
 
 outputs:
     curentRelease:
-        description: If numeric, the incremented tag of the previous release.
+        description: If numeric, the incremented base tag of the previous release.
     previousRelease:
+        description: The base tag of the previous release.
+    previousTag:
         description: The tag of the previous release.
     previousCommit:
         description: The commit of the previous release.

--- a/previous-release/index.ts
+++ b/previous-release/index.ts
@@ -6,6 +6,8 @@ type PrevReleaseData = {
 	[branch: string]: {
 		c: string;
 		t: string;
+        // Backwards compat
+        full_tag?: string;
 	}
 }
 
@@ -30,22 +32,26 @@ async function run(): Promise<void> {
 		// Allow legacy users to provide the data directly, but prefer live data if app credentials are provided
 		let data: PrevReleaseData = {};
 		if (core.getInput("appID") && core.getInput("appPrivateKey")) {
-			data = await getLivePrevReleaseData();
+            try {
+                data = await getLivePrevReleaseData();
+            } catch (ignored) {} // RequestError - data doesn't exist
 		} else {
 			data = JSON.parse(core.getInput('data') || '{}');
 		}
 
         if (!data[branch]) {
             core.setOutput('previousRelease', '0');
+            core.setOutput('previousTag', '');
             core.setOutput('previousCommit', '');
             core.setOutput('curentRelease', '1');
             return;
         }
 
-        const { c: commit, t: tag } = data[branch];
+        const { c: commit, t: tag, full_tag } = data[branch];
 
         core.setOutput('previousCommit', commit);
         core.setOutput('previousRelease', tag);
+        core.setOutput('previousTag', full_tag ? full_tag : '');
 
         const tagNum = parseInt(tag);
         if (!isNaN(tagNum)) {

--- a/release/README.md
+++ b/release/README.md
@@ -38,38 +38,43 @@ on:
 
 ### Inputs
 
-| Input                | Description                                                                                                                                            | Default | Required |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
-| `appID`              | ID of the GitHub App to manage the release system.                                                                                                     |         | `true`   |
-| `appPrivateKey`      | Private key of the GitHub App to manage the release system.                                                                                            |         | `false`  |
-| `files`              | Comma-separated or newline-separated list of release files with optional "label:" prefix.                                                              |         | `true`   |
-| `discordWebhook`     | Discord webhook to post the release to.                                                                                                                | `none`  | `false`  |
-| `discussionCategory` | The category to use for the discussion. Defaults to "none" if not specified.                                                                           | `none`  | `false`  |
-| `draftRelease`       | Whether or not the release should be a draft. Defaults to false if not specified.                                                                      | `false` | `false`  |
-| `ghApiUrl`           | The GitHub API URL to use. Defaults to the api. plus the repo domain if not specified.                                                                 | `auto`  | `false`  |
-| `ghReleaseNotes`     | Whether or not to let GitHub auto-generate its release notes. Defaults to false if not specified.                                                      | `false` | `false`  |
-| `includeReleaseInfo` | Whether or not to include the asset hashes in a release.json file. Defaults to true if not specified.                                                  | `true`  | `false`  |
-| `lastCommit`         | The last commit hash to use for the release. Defaults to the commit that triggered the workflow if not specified.                                      | `auto`  | `false`  |
-| `latestRelease`      | Whether or not the release should be marked as the latest release. Defaults to auto if not specified, which will be true unless this is a pre-release. | `auto`  | `false`  |
-| `preRelease`         | Whether or not the release is a pre-release. Inferred by the branch if not specified.                                                                  | `auto`  | `false`  |
-| `releaseBody`        | A file containing the body of the release. Defaults to the commit changelog if not specified.                                                          | `auto`  | `false`  |
-| `releaseChangeLimit` | The maximum number of changes to include in the release body. Defaults to 15 if not specified. Set to -1 to include all changes.                       | `15`    | `false`  |
-| `releaseChangePath`  | The path from which to get the changes for the release body. Defaults to the root of the repository if not specified.                                  | ``      | `false`  |
-| `releaseEnabled`     | Whether or not the release should be created. Defaults to true if not specified.                                                                       | `true`  | `false`  |
-| `releaseName`        | The title of the release. Defaults to "Build ${tagBase} (${branch})" if not specified.                                                                 | `auto`  | `false`  |
-| `releaseProject`     | The project to use for the metadata of the release. Defaults to the lowercase repository name if not specified.                                        | `auto`  | `false`  |
-| `releaseVersion`     | The version of the release. Defaults to the tag if not specified.                                                                                      | `auto`  | `false`  |
-| `saveMetadata`       | Whether or not to save the offline release metadata to metadata.json. Defaults to false if not specified.                                              | `false` | `false`  |
-| `tagBase`            | The tag base to use for the release. Auto increment from the last tag will be used if not specified.                                                   | `auto`  | `false`  |
-| `tagIncrement`       | If the build tag should be incremented. Defaults to true if not specified and tag is a number.                                                         | `true`  | `false`  |
-| `tagPrefix`          | The prefix to use for the tag. Defaults to the branch if not specified.                                                                                | `auto`  | `false`  |
-| `tagSeparator`       | The separator to use between the tag prefix and the tag base. Defaults to "-" if not specified.                                                        | `-`     | `false`  |
-| `updateReleaseData`  | Whether or not to update the release data in repository variable storage. Defaults to true if not specified                                            | `true`  | `false`  | 
+| Input                            | Description                                                                                                                                            | Default                        | Required |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|----------|
+| `appID`                          | ID of the GitHub App to manage the release system.                                                                                                     |                                | `true`   |
+| `appPrivateKey`                  | Private key of the GitHub App to manage the release system.                                                                                            |                                | `false`  |
+| `files`                          | Comma-separated or newline-separated list of release files with optional "label:" prefix.                                                              |                                | `true`   |
+| `discordWebhook`                 | Discord webhook to post the release to.                                                                                                                | `none`                         | `false`  |
+| `discordWebhookIncludeAssets`    | Whether to include links to the release assets in the post to the Discord webhook. Defaults to true if not specified.                                  | `true`                         | `false`  |
+| `discordWebhookIncludeThumbnail` | Whether to include a summary thumbnail image in the post to the Discord webhook. Defaults to true if not specified.                                    | `true`                         | `false`  |
+| `discussionCategory`             | The category to use for the discussion. Defaults to "none" if not specified.                                                                           | `none`                         | `false`  |
+| `draftRelease`                   | Whether or not the release should be a draft. Defaults to false if not specified.                                                                      | `false`                        | `false`  |
+| `ghApiUrl`                       | The GitHub API URL to use. Defaults to the api. plus the repo domain if not specified.                                                                 | `auto`                         | `false`  |
+| `ghReleaseNotes`                 | Whether or not to let GitHub auto-generate its release notes. Defaults to false if not specified.                                                      | `false`                        | `false`  |
+| `includeReleaseInfo`             | Whether or not to include the asset hashes in a release.json file. Defaults to true if not specified.                                                  | `true`                         | `false`  |
+| `lastCommit`                     | The last commit hash to use for the release. Defaults to the commit that triggered the workflow if not specified.                                      | `auto`                         | `false`  |
+| `latestRelease`                  | Whether or not the release should be marked as the latest release. Defaults to auto if not specified, which will be true unless this is a pre-release. | `auto`                         | `false`  |
+| `preRelease`                     | Whether or not the release is a pre-release. Inferred by the branch if not specified.                                                                  | `auto`                         | `false`  |
+| `releaseBody`                    | A file containing the body of the release. Defaults to the commit changelog if not specified.                                                          | `auto`                         | `false`  |
+| `releaseBodyPrefix`              | A short prefix added before the release body. Defaults to an empty string if not specified.                                                            |                                | `false`  |
+| `releaseChangeLimit`             | The maximum number of changes to include in the release body. Defaults to 15 if not specified. Set to -1 to include all changes.                       | `15`                           | `false`  |
+| `releaseChangePath`              | The path from which to get the changes for the release body. Defaults to the root of the repository if not specified.                                  | ``                             | `false`  |
+| `releaseEnabled`                 | Whether or not the release should be created. Defaults to true if not specified.                                                                       | `true`                         | `false`  |
+| `releaseName`                    | The title of the release. Defaults to "Build ${tagBase} (${branch})" if not specified.                                                                 | `auto`                         | `false`  |
+| `releaseProject`                 | The project to use for the metadata of the release. Defaults to the lowercase repository name if not specified.                                        | `auto`                         | `false`  |
+| `releaseVersion`                 | The version of the release. Defaults to the tag if not specified.                                                                                      | `auto`                         | `false`  |
+| `saveMetadata`                   | Whether or not to save the offline release metadata to metadata.json. Defaults to false if not specified.                                              | `false`                        | `false`  |
+| `tag`                            | The format of the tag. Defaults to "${prefix}${separator}${base}".                                                                                     | `${prefix}${separator}${base}` | `false`  |
+| `tagAdditional`                  | Comma-seperated or newline-separated list of additional tags to push along with the primary release tag. Defaults to an empty list if not specified.   |                                | `false`  |
+| `tagBase`                        | The tag base to use for the release. Auto increment from the last tag will be used if not specified.                                                   | `auto`                         | `false`  |
+| `tagIncrement`                   | If the build tag should be incremented. Defaults to true if not specified and tag is a number.                                                         | `true`                         | `false`  |
+| `tagPrefix`                      | The prefix to use for the tag. Defaults to the branch if not specified.                                                                                | `auto`                         | `false`  |
+| `tagSeparator`                   | The separator to use between the tag prefix and the tag base. Defaults to "-" if not specified.                                                        | `-`                            | `false`  |
+| `updateReleaseData`              | Whether or not to update the release data in repository variable storage. Defaults to true if not specified                                            | `true`                         | `false`  | 
 
 ### Outputs
 
 | Output              | Description                              |
-| ------------------- | ---------------------------------------- |
+|---------------------|------------------------------------------|
 | `releaseID`         | The ID of the release.                   |
 | `releaseAPIURL`     | The API URL of the release.              |
 | `releaseAssetsURL`  | The asset URL for the release.           |

--- a/release/action.yml
+++ b/release/action.yml
@@ -15,6 +15,14 @@ inputs:
         description: Discord webhook to post the release to.
         required: false
         default: none
+    discordWebhookIncludeAssets:
+        description: Whether to include links to the release assets in the post to the Discord webhook. Defaults to true if not specified.
+        required: false
+        default: 'true'
+    discordWebhookIncludeThumbnail:
+        description: Whether to include a summary thumbnail image in the post to the Discord webhook. Defaults to true if not specified.
+        required: false
+        default: 'true'
     discussionCategory:
         description: The category to use for the discussion. Defaults to "none" if not specified.
         required: false
@@ -51,6 +59,10 @@ inputs:
         description: A file containing the body of the release. Defaults to the commit changelog if not specified.
         required: false
         default: auto
+    releaseBodyPrefix:
+        description: A short prefix added before the release body. Defaults to an empty string if not specified.
+        required: false
+        default: ''
     releaseChangeLimit:
         description: The maximum number of changes to include in the release body. Defaults to 15 if not specified. Set to -1 to include all changes.
         required: false
@@ -83,7 +95,14 @@ inputs:
         description: The name of the offline release metadata file. Defaults to metadata.json if not specified.
         required: false
         default: metadata.json
-    tagBase: 
+    tag:
+        description: 'The format of the tag. Defaults to "${prefix}${separator}${base}".'
+        required: false
+        default: ${prefix}${separator}${base}
+    tagAdditional:
+        description: Comma-seperated or newline-separated list of additional tags to push along with the primary release tag. Defaults to an empty list if not specified.
+        required: false
+    tagBase:
         description: The tag base to use for the release. Auto increment from the last tag will be used if not specified.
         required: false
         default: auto

--- a/release/src/action/files.ts
+++ b/release/src/action/files.ts
@@ -94,7 +94,7 @@ async function uploadReleaseData(inp: {api: OctokitApi, inputs: Inputs, release:
         branch,
         id: release.data.id.toString(),
         build: parse.isPosInteger(inputs.tag.base) ? parseInt(inputs.tag.base) : inputs.tag.base,
-        tag: inputs.tag.prefix + inputs.tag.separator + inputs.tag.base,
+        tag: inputs.tag.formatted,
         timestamp: Date.now().toString(),
         prerelease: inputs.release.prerelease,
         changes: inputs.changes,

--- a/release/src/action/hook.ts
+++ b/release/src/action/hook.ts
@@ -68,8 +68,8 @@ export async function sendWebhook(inp: {inputs: Inputs, api: OctokitApi, repoDat
 
     try {
         new Webhook(inputs.release.hook)
-            .setUsername('GitHub Release Action')
-            .setAvatarUrl('https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png')
+            .setUsername('GitHub Actions')
+            .setAvatarUrl('https://media.discordapp.net/attachments/472838100951760928/1244710120424738976/github-actions-logo.png')
             .addEmbed(embed)
             .send();
     } catch (error) {

--- a/release/src/action/hook.ts
+++ b/release/src/action/hook.ts
@@ -22,14 +22,16 @@ export async function sendWebhook(inp: {inputs: Inputs, api: OctokitApi, repoDat
     const updatedRelease = await api.rest.repos.getRelease({ owner, repo, release_id: releaseResponse.data.id });
     const tag = updatedRelease.data.tag_name;
 
-    const thumbnail= `https://opengraph.githubassets.com/1/${owner}/${repo}/releases/tag/${tag}`;
+    const thumbnail = `https://opengraph.githubassets.com/1/${owner}/${repo}/releases/tag/${tag}`;
 
     let assets = '';
-    for (const asset of updatedRelease.data.assets) {
-        assets += `- :page_facing_up: [${asset.name}](${asset.browser_download_url})\n`;
+    if (inputs.release.hookIncludeAssets) {
+        for (const asset of updatedRelease.data.assets) {
+            assets += `- :page_facing_up: [${asset.name}](${asset.browser_download_url})\n`;
+        }
+        assets += `- :package: [Source code (zip)](${updatedRelease.data.zipball_url})\n`;
+        assets += `- :package: [Source code (tar.gz)](${updatedRelease.data.tarball_url})\n`;
     }
-    assets += `- :package: [Source code (zip)](${updatedRelease.data.zipball_url})\n`;
-    assets += `- :package: [Source code (tar.gz)](${updatedRelease.data.tarball_url})\n`;
 
     const time = Math.floor(new Date(updatedRelease.data.created_at).getTime() / 1000);
     const author = updatedRelease.data.author.type === 'User' ? updatedRelease.data.author.login : updatedRelease.data.author.login.replace('[bot]', '');
@@ -48,15 +50,19 @@ export async function sendWebhook(inp: {inputs: Inputs, api: OctokitApi, repoDat
         .setColor(color)
         .setTitle(inputs.release.name)
         .setUrl(updatedRelease.data.html_url)
-        .setDescription(inputs.release.body)
-        .addField({ name: 'Assets', value: assets, inline: false })
-        .addField({ name: '', value: `:watch: <t:${time}:R>`, inline: true })
+        .setDescription(inputs.release.body);
+
+    if (inputs.release.hookIncludeAssets) {
+        embed.addField({ name: 'Assets', value: assets, inline: false });
+    }
+
+    embed.addField({ name: '', value: `:watch: <t:${time}:R>`, inline: true })
         .addField({ name: '', value: `:label: [${tag}](${url}/${owner}/${repo}/tree/${tag})`, inline: true })
         .addField({ name: '', value: `:lock_with_ink_pen: [${sha}](${url}/${owner}/${repo}/commit/${sha})`, inline: true })
         .addField({ name: '', value: `${statusEmoji} [${status}](${url}/${owner}/${repo}/actions/runs/${runID})`, inline: true })
         .setFooter({ text: `Released by ${author}`, icon_url: updatedRelease.data.author.avatar_url })
 
-    if (thumbnail) {
+    if (inputs.release.hookIncludeThumbnail) {
         embed.setImage({ url: thumbnail });
     }
 

--- a/release/src/action/inputs.ts
+++ b/release/src/action/inputs.ts
@@ -233,7 +233,7 @@ async function getReleaseBody(inp: {repoData: Repo, changes: Inputs.Change[], su
     const { repoData, changes, success } = inp;
 
     let bodyPrefix = core.getInput('releaseBodyPrefix');
-    const bodyPath = core.getInput('releaseBodyPath'); // FIXME is this right?
+    const bodyPath = core.getInput('releaseBody');
 
     if (bodyPrefix) {
         bodyPrefix = `${bodyPrefix}${os.EOL}`;

--- a/release/src/action/inputs.ts
+++ b/release/src/action/inputs.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 import fs from 'fs';
 import { Inputs, PreviousRelease } from '../types/inputs';
 import * as parse from '../util/parse';
+import * as strings from '../util/strings';
 import { Repo } from '../types/repo';
 import os from 'os';
 import path from 'path';
@@ -17,11 +18,12 @@ export async function getInputs(inp: {api: OctokitApi, repoData: Repo}): Promise
     const files = getFiles();
     const changes = await getChanges({api, prevRelease, repoData});
     const tag = await getTag({repoData, prevRelease});
+    const additionalTags = getAdditionalTags();
     const success = await getSuccess({api, repoData});
     const release = await getRelease({api, changes, tag, repoData, success});
 
-    console.log(`Using ${files.length} files, ${changes.length} changes, tag ${tag.base}, release ${release.name}`);
-    return { files, changes, tag, release, success };
+    console.log(`Using ${files.length} files, ${changes.length} changes, tag ${tag.formatted}, release ${release.name}`);
+    return { files, changes, tag, additionalTags, release, success };
 }
 
 async function getPrevRelease(inp: {api: OctokitApi, repoData: Repo}): Promise<PreviousRelease> {
@@ -99,7 +101,9 @@ async function getRelease(inp: {api: OctokitApi, changes: Inputs.Change[], tag: 
     const discussion_category_name = await getDiscussionCategory({api, owner, repo});
     const make_latest = getMakeLatest({prerelease, success});
     const info = core.getBooleanInput('includeReleaseInfo');
-    const hook = core.getInput('discordWebhook') == 'none' ? undefined : core.getInput('discordWebhook');
+    const hook = core.getInput('discordWebhook') === 'none' ? undefined : core.getInput('discordWebhook');
+    const hookIncludeAssets = core.getInput('discordWebhookIncludeAssets') === 'true';
+    const hookIncludeThumbnail = core.getInput('discordWebhookIncludeThumbnail') === 'true';
     const enabled = core.getBooleanInput('releaseEnabled');
     const metadata = core.getBooleanInput('saveMetadata');
     const metadata_name = core.getInput("metadataName");
@@ -108,7 +112,7 @@ async function getRelease(inp: {api: OctokitApi, changes: Inputs.Change[], tag: 
     const version = core.getInput('releaseVersion') === 'auto' ? tag.base : core.getInput('releaseVersion');
 
     console.log(`Using release name ${name} with prerelease: ${prerelease}, draft: ${draft}, generate release notes: ${generate_release_notes}, discussion category: ${discussion_category_name}, make latest: ${make_latest}, include release info: ${info}`);
-    return { name, body, prerelease, draft, generate_release_notes, discussion_category_name, make_latest, info, hook, enabled, metadata, metadata_name, update_release_data, project, version };
+    return { name, body, prerelease, draft, generate_release_notes, discussion_category_name, make_latest, info, hook, hookIncludeAssets, hookIncludeThumbnail, enabled, metadata, metadata_name, update_release_data, project, version };
 }
 
 async function getSuccess(inp: {api: OctokitApi, repoData: Repo}): Promise<boolean> {
@@ -137,34 +141,41 @@ async function getSuccess(inp: {api: OctokitApi, repoData: Repo}): Promise<boole
 
     return success;
 }
+
 async function getTag(inp: {repoData: Repo, prevRelease: PreviousRelease}): Promise<Inputs.Tag> {
     const { repoData, prevRelease } = inp;
 
     const { branch } = repoData;
 
-    const base = core.getInput('tagBase');
+    const baseInput = core.getInput('tagBase');
     const separator = core.getInput('tagSeparator');
     const prefix = core.getInput('tagPrefix') == 'auto' ? branch : core.getInput('tagPrefix');
     const increment = core.getBooleanInput('tagIncrement');
+    const template = core.getInput('tag');
 
-    if (base === 'auto') {
+    let base = '1';
+    if (baseInput === 'auto') {
         if (prevRelease.baseTag != null && parse.isPosInteger(prevRelease.baseTag)) {
-            const buildNumber = parseInt(prevRelease.baseTag) + (increment ? 1 : 0);
-            return { base: buildNumber.toString(), prefix, separator, increment };
+            base = (parseInt(prevRelease.baseTag) + (increment ? 1 : 0)).toString();
         }
-
-        if (prevRelease.baseTag == null) {
-            return { base: '1', prefix, separator, increment };
-        }
+    } else if (parse.isPosInteger(baseInput) && increment) {
+        base = (parseInt(baseInput) + 1).toString();
     }
 
-    if (parse.isPosInteger(base) && increment) {
-        const buildNumber = parseInt(base) + 1;
-        return { base: buildNumber.toString(), prefix, separator, increment };
+    const formatted = strings.formatString(template, { base: base, prefix, separator });
+
+    console.log(`Using release tag ${formatted} with increment: ${increment}`);
+    return { base, prefix, separator, increment, formatted };
+}
+
+function getAdditionalTags(): string[] {
+    const additionalTags = core.getInput('tagAdditional');
+
+    if (additionalTags === '') {
+        return [];
     }
 
-    console.log(`Using release tag ${prefix}${separator}${base} with increment: ${increment}`);
-    return { base, prefix, separator, increment };
+    return parse.parseMultiInput(additionalTags);
 }
 
 async function getChanges(inp: {api: OctokitApi, prevRelease: PreviousRelease, repoData: Repo}): Promise<Inputs.Change[]> {
@@ -221,7 +232,12 @@ async function getChanges(inp: {api: OctokitApi, prevRelease: PreviousRelease, r
 async function getReleaseBody(inp: {repoData: Repo, changes: Inputs.Change[], success: boolean}): Promise<string> {
     const { repoData, changes, success } = inp;
 
-    const bodyPath = core.getInput('releaseBodyPath');
+    let bodyPrefix = core.getInput('releaseBodyPrefix');
+    const bodyPath = core.getInput('releaseBodyPath'); // FIXME is this right?
+
+    if (bodyPrefix) {
+        bodyPrefix = `${bodyPrefix}${os.EOL}`;
+    }
 
     if (!fs.existsSync(bodyPath)) {
         // Generate release body ourselves
@@ -266,10 +282,10 @@ async function getReleaseBody(inp: {repoData: Repo, changes: Inputs.Change[], su
             changelog += `... and ${truncatedChanges} more${os.EOL}`;
         }
 
-        return changelog;
+        return `${bodyPrefix}${changelog}`;
     }
 
-    return fs.readFileSync(bodyPath, { encoding: 'utf-8' });
+    return `${bodyPrefix}${fs.readFileSync(bodyPath, { encoding: 'utf-8' })}`;
 }
 
 async function getPreRelease(inp: {repoData: Repo}): Promise<boolean> {

--- a/release/src/action/output.ts
+++ b/release/src/action/output.ts
@@ -15,7 +15,7 @@ export async function setOutputs(inp: {release: ReleaseResponse | null, inputs: 
 
     core.setOutput('body', inputs.release.body);
 
-    const tag = inputs.tag.prefix + inputs.tag.separator + inputs.tag.base;
+    const tag = inputs.tag.formatted;
 
     core.setOutput('tag', tag);
     core.setOutput('tagPrefix', inputs.tag.prefix);

--- a/release/src/action/release.ts
+++ b/release/src/action/release.ts
@@ -12,7 +12,7 @@ export async function writeRelease(inp: {inputs: Inputs, api: OctokitApi, repoDa
 
     const { owner, repo, branch } = repoData;
 
-    const tag_name = inputs.tag.prefix + inputs.tag.separator + inputs.tag.base;
+    const tag_name = inputs.tag.formatted;
     const target_commitish = branch;
     const { name, body, draft, prerelease, discussion_category_name, generate_release_notes, make_latest } = inputs.release;
 
@@ -29,6 +29,24 @@ export async function writeRelease(inp: {inputs: Inputs, api: OctokitApi, repoDa
         generate_release_notes,
         make_latest
     });
+
+    if (inputs.additionalTags) {
+        for (const i in inputs.additionalTags) {
+            const ref = `tags/${inputs.additionalTags[i]}`;
+            let exists = true;
+            try {
+                await api.rest.git.getRef({ owner, repo, ref: `tags/${inputs.additionalTags[i]}` });
+            } catch (error) {
+                exists = false;
+            }
+
+            if (exists) {
+                await api.rest.git.updateRef({ owner, repo, ref, sha: repoData.lastCommit });
+            } else {
+                await api.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha: repoData.lastCommit });
+            }
+        }
+    }
 
     console.log(`Release ${releaseResponse.data.id} created at ${releaseResponse.data.html_url}`);
     return releaseResponse;

--- a/release/src/action/repo.ts
+++ b/release/src/action/repo.ts
@@ -1,6 +1,5 @@
 import { BaseRepo } from "../types/repo";
 import * as parse from '../util/parse';
-import * as core from '@actions/core'
 
 export function getRepoData(): BaseRepo {
     if(!process.env.GITHUB_REPOSITORY) {

--- a/release/src/action/store.ts
+++ b/release/src/action/store.ts
@@ -34,7 +34,7 @@ async function checkStoreReleaseData(inp: {inputs: Inputs, api: OctokitApi, repo
     const { inputs, api, repoData, lastCommit } = inp;
 
     const { owner, repo, branch } = repoData;
-    const newEntry = { c: lastCommit, t: inputs.tag.base };
+    const newEntry = { c: lastCommit, t: inputs.tag.base, full_tag: inputs.tag.formatted };
 
     const variable = 'releaseAction_prevRelease';
     const varResponse = await api.rest.actions.getRepoVariable({ owner, repo, name: variable });

--- a/release/src/types/inputs.ts
+++ b/release/src/types/inputs.ts
@@ -2,6 +2,7 @@ export interface Inputs {
     readonly files: Inputs.File[];
     readonly changes: Inputs.Change[];
     readonly tag: Inputs.Tag;
+    readonly additionalTags: string[];
     readonly release: Inputs.Release;
     readonly success: boolean;
 }
@@ -12,6 +13,7 @@ export namespace Inputs {
         readonly prefix: string;
         readonly increment: boolean;
         readonly separator: string;
+        readonly formatted: string;
     }
 
     export interface File {
@@ -39,6 +41,8 @@ export namespace Inputs {
         readonly make_latest: "true" | "false" | "legacy" | undefined;
         readonly info: boolean;
         readonly hook: string | undefined;
+        readonly hookIncludeAssets: boolean;
+        readonly hookIncludeThumbnail: boolean;
         readonly metadata: boolean;
         readonly metadata_name: string;
         readonly update_release_data: boolean;

--- a/release/src/util/strings.ts
+++ b/release/src/util/strings.ts
@@ -1,0 +1,6 @@
+export function formatString(input: string, variables: Record<string, any>): string {
+    for (const key in variables) {
+        input = input.replaceAll(`\${${key}}`, variables[key]);
+    }
+    return input;
+}


### PR DESCRIPTION
This PR adds the following options to the `release` action:

- `discordWebhookIncludeAssets` - Whether to include links to the release assets in the post to the Discord webhook. Defaults to true if not specified.
- `discordWebhookIncludeThumbnail` - Whether to include a summary thumbnail image in the post to the Discord webhook. Defaults to true if not specified.
- `releaseBodyPrefix` - A short prefix added before the release body. Defaults to an empty string if not specified.
- `tag` - The format of the tag. Defaults to `"${prefix}${separator}${base}"`.
- `tagAdditional` - Comma-seperated or newline-separated list of additional tags to push along with the primary release tag. Defaults to an empty list if not specified.

The PR also adds functionality to store the fully formatted tag name in the `releaseAction_prevRelease` action variable, and adds it as an action output (`previousTag`) to the `previous-release` action. Lastly, the `releaseBody` input of the `release` action has been fixed, and the Discord webhook of the `release` action now has a consistent username/avatar with the `notify-discord` action.

The PR has been tested in a forked repository.